### PR TITLE
expose sql.Db through DataSource interface

### DIFF
--- a/dsync.go
+++ b/dsync.go
@@ -1,6 +1,7 @@
 package dsync
 
 import (
+	"database/sql"
 	"io/fs"
 	"path/filepath"
 	"sort"
@@ -73,6 +74,9 @@ type DataSource interface {
 
 	// EndTransaction EndTransaction Commit or rollback the active transaction
 	EndTransaction()
+
+	// Return the underlying database handle
+	Handle() *sql.DB
 }
 
 type Config struct {

--- a/sources/mysql/mysql.go
+++ b/sources/mysql/mysql.go
@@ -190,3 +190,7 @@ func (p mysqlDataSource) logMigration(m *dsync.Migration) error {
 	}
 	return nil
 }
+
+func (ds mysqlDataSource) Handle() *sql.DB {
+	return ds.db
+}

--- a/sources/postgresql/postgresql.go
+++ b/sources/postgresql/postgresql.go
@@ -197,3 +197,7 @@ func (p pgDataSource) logMigration(m *dsync.Migration) error {
 	}
 	return nil
 }
+
+func (ds pgDataSource) Handle() *sql.DB {
+	return ds.db
+}

--- a/sources/sqlite/sqslite.go
+++ b/sources/sqlite/sqslite.go
@@ -191,3 +191,7 @@ func (p sqliteDataSource) logMigration(m *dsync.Migration) error {
 	}
 	return nil
 }
+
+func (ds sqliteDataSource) Handle() *sql.DB {
+	return ds.db
+}


### PR DESCRIPTION
Exposes database/sql.DB struct through the DataSource interface.

Simplifies obtaining access to the underlying database connection