### PR TITLE
Switch to path join

### DIFF
--- a/sources/mysql/mysql.go
+++ b/sources/mysql/mysql.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"io"
 	"io/fs"
-	"path/filepath"
+	"path"
 	"strings"
 	"time"
 
@@ -160,7 +160,7 @@ func (ds *mysqlDataSource) GetMigrationInfo() (*dsync.MigrationInfo, error) {
 func (ds *mysqlDataSource) ApplyMigration(m *dsync.Migration) error {
 	var buf []byte
 	var sb strings.Builder
-	f, err := ds.setFS.Open(filepath.Join(ds.basepath, m.File))
+	f, err := ds.setFS.Open(path.Join(ds.basepath, m.File))
 
 	m.Success = false
 	m.CreatedAt = time.Now()

--- a/sources/postgresql/postgresql.go
+++ b/sources/postgresql/postgresql.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"io"
 	"io/fs"
-	"path/filepath"
+	"path"
 	"strings"
 	"time"
 
@@ -166,7 +166,7 @@ func (ds *pgDataSource) GetMigrationInfo() (*dsync.MigrationInfo, error) {
 func (ds *pgDataSource) ApplyMigration(m *dsync.Migration) error {
 	var buf []byte
 	var sb strings.Builder
-	f, err := ds.setFS.Open(filepath.Join(ds.basepath, m.File))
+	f, err := ds.setFS.Open(path.Join(ds.basepath, m.File))
 
 	m.Success = false
 	m.CreatedAt = time.Now()

--- a/sources/sqlite/sqslite.go
+++ b/sources/sqlite/sqslite.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/fs"
 	"path/filepath"
+	"path"
 	"strings"
 	"time"
 
@@ -159,7 +160,7 @@ func (ds *sqliteDataSource) GetMigrationInfo() (*dsync.MigrationInfo, error) {
 func (ds *sqliteDataSource) ApplyMigration(m *dsync.Migration) error {
 	var buf []byte
 	var sb strings.Builder
-	f, err := ds.setFS.Open(filepath.Join(ds.basepath, m.File))
+	f, err := ds.setFS.Open(path.Join(ds.basepath, m.File))
 
 	m.Success = false
 	m.CreatedAt = time.Now()

--- a/sources/sqlite/sqslite.go
+++ b/sources/sqlite/sqslite.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"io"
 	"io/fs"
-	"path/filepath"
 	"path"
 	"strings"
 	"time"


### PR DESCRIPTION
Move away from `filepath.Join` to `path.Join`, as the former breaks on windows due to `\\` path separator.